### PR TITLE
Add --clobber flag to release upload step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Upload Release Asset
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ github.event.release.tag_name }} ./build/distributions/*
+        run: gh release upload ${{ github.event.release.tag_name }} ./build/distributions/* --clobber
 
       # Create a pull request
       - name: Create Pull Request


### PR DESCRIPTION
The --clobber flag ensures that existing assets with the same name are overwritten during the release upload process. This change is necessary to prevent conflicts with prior builds and ensure the latest build artifacts are always used.